### PR TITLE
Added filtering capability

### DIFF
--- a/_build/data/transport.chunks.php
+++ b/_build/data/transport.chunks.php
@@ -9,6 +9,15 @@ $chunks[1]->fromArray(array(
     'properties' => '',
 ),'',true,true);
 
+$chunks[2]= $modx->newObject('modChunk');
+$chunks[2]->fromArray(array(
+    'id' => 1,
+    'name' => 'notifyDefaultFilter',
+    'description' => '',
+    'snippet' => file_get_contents($sources['source_core'].'/elements/chunks/notifydefaultfilter.chunk.tpl'),
+    'properties' => '',
+),'',true,true);
+
 foreach ($chunks as $ch) {
     $attributes= array(
         xPDOTransport::UNIQUE_KEY => 'name',

--- a/_build/data/transport.settings.php
+++ b/_build/data/transport.settings.php
@@ -3,6 +3,7 @@ $s = array(
     'mailTo' => '',
     'mailFrom' => '',
     'mailReplyto' => '',
+    'filter' => 'notifyDefaultFilter',
     'mailTemplate' => 'notifyDefaultTpl',
     'autoban' => true,
     'autoban.expiration' => 5,

--- a/core/components/notify404/elements/chunks/notifydefaultfilter.chunk.tpl
+++ b/core/components/notify404/elements/chunks/notifydefaultfilter.chunk.tpl
@@ -1,0 +1,6 @@
+ua: Ezooms/1.0
+ua: YandexImages/3.0
+ua: bingbot/2.0
+ua: Googlebot-Image/1.0
+ua: Googlebot/2.1
+url: testNotifyFilter


### PR DESCRIPTION
Added feature to allow users to filter out notifications. Options are ua (user agent), ip (IP address), url (request) and host (your host, not the user's).

Filtering is done by setting notify404.filter system setting to a chunk name and filling the chunk with rule keypairs. See default chunk notifyDefaultFilter for examples.

Lightly tested, did not test updated installation package yet.
